### PR TITLE
Adding help message from the mailgun error

### DIFF
--- a/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
+++ b/ghost/core/core/server/services/bulk-email/bulk-email-processor.js
@@ -256,7 +256,8 @@ module.exports = {
             let ghostError = new errors.EmailError({
                 err: error,
                 context: tpl(messages.error),
-                code: 'BULK_EMAIL_SEND_FAILED'
+                code: 'BULK_EMAIL_SEND_FAILED',
+                help: error.error.details
             });
 
             sentry.captureException(ghostError);


### PR DESCRIPTION
The mailgun errors are not detailed in the Ghost logs.
Writing the Mailgun help message in the help attribute could be helpfull for users.

https://github.com/TryGhost/Ghost/issues/15437